### PR TITLE
Release 1.0.0: remove support for Python 3.6, 3.7; fix linting errors

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 1.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize =
 	{major}.{minor}.{patch}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Lint
 
 on: [push]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: 'pip'
+          cache-dependency-path: setup.py
+
+      - run: pip3 install -e '.[test]'
+      - run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [push]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: 'pip'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
           cache-dependency-path: setup.py
 
       - run: pip3 install -e '.[test]'
-      - run: make lint
+      - run: make lint-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,14 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 .idea/
 .python-version
 venv
+.venv

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,3 +11,6 @@ python = "3.9"
 
 [tasks.test]
 run = 'make install test'
+
+[tasks.lint]
+run = 'make install lint'

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,13 @@
+[env]
+MISE_FETCH_REMOTE_VERSIONS_TIMEOUT = "30s"
+
+_.python.venv = {
+  path = ".venv",
+  create = true,
+}
+
+[tools]
+python = "3.9"
+
+[tasks.test]
+run = 'make install test'

--- a/.mise.toml
+++ b/.mise.toml
@@ -6,6 +6,10 @@ _.python.venv = {
   create = true,
 }
 
+[settings]
+python.uv_venv_auto = false
+python.venv_stdlib = true
+
 [tools]
 python = "3.11"
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -7,7 +7,7 @@ _.python.venv = {
 }
 
 [tools]
-python = "3.9"
+python = "3.11"
 
 [tasks.test]
 run = 'make install test'

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ install:
 	pip install --edit .[test]
 
 test:
-	pylint --rcfile=.pylintrc --reports=y --exit-zero customerio/analytics
-	flake8 --max-complexity=10 --statistics customerio/analytics || true
 	python -m unittest customerio/analytics/test/*.py -v
 
-.PHONY: install test
+lint:
+	pylint --rcfile=.pylintrc --reports=y --exit-zero customerio/analytics
+	flake8 --max-complexity=10 --statistics customerio/analytics || true
+
+.PHONY: install test lint

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,12 @@ lint:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero customerio/analytics
 	flake8 --max-complexity=10 --statistics --exit-zero customerio/analytics
 
+lint-ci:
+	pylint --rcfile=.pylintrc --exit-zero --fail-on=E customerio/analytics
+	flake8 --max-complexity=10 --max-line-length=100 --statistics customerio/analytics
+
 clean:
 	rm -rf .venv
 	mise deps
 
-.PHONY: install test lint clean
+.PHONY: install test lint lint-ci clean

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,8 @@ lint:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero customerio/analytics
 	flake8 --max-complexity=10 --statistics customerio/analytics || true
 
-.PHONY: install test lint
+clean:
+	rm -rf .venv
+	mise deps
+
+.PHONY: install test lint clean

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 
 lint:
 	pylint --rcfile=.pylintrc --reports=y --exit-zero customerio/analytics
-	flake8 --max-complexity=10 --statistics customerio/analytics || true
+	flake8 --max-complexity=10 --statistics --exit-zero customerio/analytics
 
 clean:
 	rm -rf .venv

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿Customer.io Data Pipelines analytics client for Python.
+﻿# Customer.io Data Pipelines analytics client for Python.
 
 ## Installation
 
@@ -40,6 +40,6 @@ analytics.track(user_id=4, event='order_complete')
 
 The links below contain more detailed documentation on how to use this library:
 
-* [Documentation](https://customer.io/docs/cdp/sources/connections/servers/python/)
-* [Specs](https://customer.io/docs/cdp/sources/source-spec/source-events/)
+* [Documentation](https://docs.customer.io/integrations/data-in/connections/servers/python/)
+* [Specs](https://docs.customer.io/integrations/data-in/source-spec/incoming-data/)
 * [PyPi](https://pypi.org/project/customerio-cdp-analytics/)

--- a/customerio/analytics/client.py
+++ b/customerio/analytics/client.py
@@ -1,18 +1,17 @@
-from datetime import datetime
-from uuid import uuid4
-import logging
-import numbers
 import atexit
 import json
+import logging
+import numbers
+import queue
+from datetime import datetime
+from uuid import uuid4
 
 from dateutil.tz import tzutc
 
-from customerio.analytics.utils import guess_timezone, clean
 from customerio.analytics.consumer import Consumer, MAX_MSG_SIZE
 from customerio.analytics.request import post, DatetimeSerializer
+from customerio.analytics.utils import guess_timezone, clean
 from customerio.analytics.version import VERSION
-
-import queue
 
 ID_TYPES = (numbers.Number, str)
 
@@ -269,7 +268,9 @@ class Client(object):
         # Check message size.
         msg_size = len(json.dumps(msg, cls=DatetimeSerializer).encode())
         if msg_size > MAX_MSG_SIZE:
-            raise RuntimeError('Message exceeds %skb limit. (%s)', str(int(MAX_MSG_SIZE / 1024)), str(msg))
+            raise RuntimeError(
+                'Message exceeds %dkb limit. (%s)' % (MAX_MSG_SIZE // 1024, msg)
+            )
 
         # if send is False, return msg as if it was successfully queued
         if not self.send:

--- a/customerio/analytics/consumer.py
+++ b/customerio/analytics/consumer.py
@@ -1,12 +1,12 @@
-import logging
-from threading import Thread
-import monotonic
-import backoff
 import json
+import logging
+from queue import Empty
+from threading import Thread
+
+import backoff
+import monotonic
 
 from customerio.analytics.request import post, APIError, DatetimeSerializer
-
-from queue import Empty
 
 MAX_MSG_SIZE = 32 << 10
 
@@ -73,7 +73,7 @@ class Consumer(Thread):
             # mark items as acknowledged from queue
             for _ in batch:
                 self.queue.task_done()
-            return success
+        return success
 
     def next(self):
         """Return the next batch of items to upload."""

--- a/customerio/analytics/request.py
+++ b/customerio/analytics/request.py
@@ -56,8 +56,8 @@ def post(write_key, host=None, gzip=False, timeout=15, proxies=None, **kwargs):
         payload = res.json()
         log.debug('received response: %s', payload)
         raise APIError(res.status_code, payload['code'], payload['message'])
-    except ValueError:
-        raise APIError(res.status_code, 'unknown', res.text)
+    except ValueError as exc:
+        raise APIError(res.status_code, 'unknown', res.text) from exc
 
 
 class APIError(Exception):

--- a/customerio/analytics/test/consumer.py
+++ b/customerio/analytics/test/consumer.py
@@ -1,7 +1,8 @@
-import unittest
-import mock
-import time
 import json
+import time
+import unittest
+
+import mock
 
 try:
     from queue import Queue

--- a/customerio/analytics/version.py
+++ b/customerio/analytics/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.2'
+VERSION = '0.1.0'

--- a/customerio/analytics/version.py
+++ b/customerio/analytics/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.1.0'
+VERSION = '1.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ monotonic==1.6
 mock==2.0.0
 pylint==3.3.3
 python-dateutil==2.8.2
-requests>=2.32.2
+requests>=2.32.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+backoff==2.2.1
+monotonic==1.6
+mock==2.0.0
+pylint==3.3.3
+python-dateutil==2.8.2
+requests>=2.32.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 backoff==2.2.1
+flake8==3.7.9
 monotonic==1.6
 mock==2.0.0
 pylint==3.3.3

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ setup(
     maintainer_email='cdp@customer.io',
     test_suite='analytics.test.all',
     packages=['customerio.analytics'],
-    # Newer versions are not tested with Python 3.6 or 3.7.
-    python_requires='>=3.6.0',
+    python_requires='>=3.8.0',
     license='MIT License',
     install_requires=install_requires,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -16,15 +16,15 @@ This is the official python client that wraps the Customer.io Data Pipelines RES
 '''
 
 install_requires = [
-    "requests~=2.7",
-    "monotonic~=1.5",
-    "backoff~=2.1",
-    "python-dateutil~=2.2"
+    "requests>=2.32.2",
+    "monotonic~=1.6",
+    "backoff~=2.2",
+    "python-dateutil~=2.8"
 ]
 
 tests_require = [
     "mock==2.0.0",
-    "pylint==2.8.0",
+    "pylint==3.3.3",
     "flake8==3.7.9",
 ]
 
@@ -38,6 +38,7 @@ setup(
     maintainer_email='cdp@customer.io',
     test_suite='analytics.test.all',
     packages=['customerio.analytics'],
+    # Newer versions are not tested with Python 3.6 or 3.7.
     python_requires='>=3.6.0',
     license='MIT License',
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
 
 tests_require = [
     "mock==2.0.0",
-    "pylint==3.3.3",
+    "pylint>=3.2.0",
     "flake8==3.7.9",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,10 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ This is the official python client that wraps the Customer.io Data Pipelines RES
 '''
 
 install_requires = [
-    "requests>=2.32.2",
+    "requests>=2.32.4",
     "monotonic~=1.6",
     "backoff~=2.2",
     "python-dateutil~=2.8"


### PR DESCRIPTION
Changes:

 * Remove support for Python 3.6 and 3.7. We need to use a version of requests later than 2.32.0, because there are important security fixes. [requests changelog](https://requests.readthedocs.io/en/latest/community/updates/#id11)
 * Bump version to 1.0.0, since removing support for Python versions is a breaking change.
 * Fix pylint errors: missing `__init__.py`, import ordering, exception handling
   * Add `customerio/__init__.py` so pylint can resolve the package hierarchy.
   * Fix raise-missing-from, return-in-finally, and import ordering warnings.
   * Fix `RuntimeError` formatting bug where %-placeholders were not interpolated.
 * Easier local dev experience using mise and venvs.
 * Split linting out of tests.
 * Fail CI on linting errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for users on Python 3.6/3.7 and a major version bump; dependency floor changes install behavior, though application logic changes are small.
> 
> **Overview**
> **Major release 1.0.0** drops Python 3.6/3.7 (`python_requires>=3.8`) and raises **`requests` to `>=2.32.4`** (and related pins) for security fixes. Version is bumped in `.bumpversion.cfg` and `version.py`.
> 
> **CI and local dev** are reworked: a dedicated **Lint** workflow runs `make lint-ci`; tests no longer run pylint/flake8. The test matrix covers **3.8–3.14** with `fail-fast: false`, and GitHub Actions use **checkout/setup-python v6**. **mise** (`.mise.toml`) and `.venv` in `.gitignore` support local workflows; `Makefile` adds `lint`, `lint-ci`, and `clean`.
> 
> **Small runtime fixes:** oversized-message `RuntimeError` in `client.py` uses correct formatting; `consumer.py` returns upload success outside `finally`; `request.py` chains `ValueError` when building `APIError`. README doc URLs are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc5d6ad37d93a57dd64e55cbccdf0ed4d812e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->