### PR TITLE
Fix release workflow: add setuptools dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install bump2version twine wheel
+          python -m pip install bump2version twine wheel setuptools
 
       - name: Bump version
         run: |


### PR DESCRIPTION
## Summary
- Python 3.14 no longer bundles `setuptools`, causing the release workflow to fail with `ModuleNotFoundError: No module named 'setuptools'` when running `python setup.py sdist bdist_wheel`
- Adds `setuptools` to the `pip install` step in the release workflow

## Test plan
- [ ] Re-run the release workflow and confirm it passes the Publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI dependency change with no application or security impact.
> 
> **Overview**
> The release workflow’s **Install dependencies** step now installs **`setuptools`** alongside `bump2version`, `twine`, and `wheel`.
> 
> That unblocks the **Publish** step (`python setup.py sdist bdist_wheel`) on newer Python versions (e.g. 3.14) where `setuptools` is no longer bundled, which was causing `ModuleNotFoundError: No module named 'setuptools'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703d7b6f4b27dc384e13d4d68ee311b4fe3eebce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->