### PR TITLE
Project name must match PyPi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "customerio_cdp_analytics"
+name = "customerio-cdp-analytics"
 dynamic = ["version"]
 # Version is derived from git tags via setuptools-scm (e.g. tag v3.0.0 → version 3.0.0)
 description = "Customer.io Data Pipelines (CDP) Python bindings."


### PR DESCRIPTION
Following on from https://github.com/customerio/cdp-analytics-python/pull/8 , we need to update the project name in pyproject.toml to match the name in PyPi for trusted publishing workflows. Otherwise they will fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field change with no runtime or import-path impact; only affects how the distribution is named on publish.
> 
> **Overview**
> Updates the **`[project].name`** in `pyproject.toml` from `customerio_cdp_analytics` to **`customerio-cdp-analytics`** so it matches the name on PyPI.
> 
> This is required for **trusted publishing** workflows to succeed after the related packaging changes in the prior PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115e3c21cdbfad1d907883c10897b0fcf7995a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->