### PR TITLE
Ensure proxies and timeout options are handled correctly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+## Pull Requests
+
+PRs MUST be opened against **customerio/cdp-analytics-python** (branch: `main`).
+
+Never open PRs against segmentio/analytics-python — this repo is a fork and we do not contribute upstream.
+
+When creating a PR, always use: `gh pr create --repo customerio/cdp-analytics-python --base main`
+
+## Tests
+
+Run tests with: `make test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/customerio/analytics/request.py
+++ b/customerio/analytics/request.py
@@ -42,7 +42,7 @@ def post(write_key, host=None, gzip=False, timeout=15, proxies=None, **kwargs):
         "timeout": timeout,
     }
 
-    if proxies:
+    if proxies is not None:
         kwargs['proxies'] = proxies
 
     res = _session.post(url, **kwargs)

--- a/customerio/analytics/request.py
+++ b/customerio/analytics/request.py
@@ -39,14 +39,13 @@ def post(write_key, host=None, gzip=False, timeout=15, proxies=None, **kwargs):
         "data": data,
         "auth": auth,
         "headers": headers,
-        "timeout": 15,
+        "timeout": timeout,
     }
 
     if proxies:
         kwargs['proxies'] = proxies
 
-    res = _session.post(url, data=data, auth=auth,
-                        headers=headers, timeout=timeout)
+    res = _session.post(url, **kwargs)
 
     if res.status_code == 200:
         log.debug('data uploaded successfully')

--- a/customerio/analytics/test/client.py
+++ b/customerio/analytics/test/client.py
@@ -343,6 +343,16 @@ class TestClient(unittest.TestCase):
             self.assertEqual(consumer.timeout, 15)
 
     def test_proxies(self):
-        client = Client('testsecret', proxies='203.243.63.16:80')
-        success, msg = client.identify('userId', {'trait': 'value'})
-        self.assertTrue(success)
+        proxies = {
+            'https': 'http://proxy.example.com:8080',
+            'http': 'http://proxy.example.com:8080',
+        }
+        client = Client('testsecret', sync_mode=True, proxies=proxies)
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        with mock.patch('customerio.analytics.request._session.post',
+                        return_value=mock_response) as mock_post:
+            client.identify('userId', {'trait': 'value'})
+            mock_post.assert_called_once()
+            _, call_kwargs = mock_post.call_args
+            self.assertEqual(call_kwargs['proxies'], proxies)

--- a/customerio/analytics/test/client.py
+++ b/customerio/analytics/test/client.py
@@ -324,7 +324,8 @@ class TestClient(unittest.TestCase):
             self.assertEqual(len(kwargs['batch']), 10)
 
         # the post function should be called 2 times, with a batch size of 10
-        # each time.
+        # each time. 0.3s upload_interval ensures both batches are sent
+        # during 1 second sleep.
         with mock.patch('customerio.analytics.consumer.post', side_effect=mock_post_fn) \
                 as mock_post:
             for _ in range(20):

--- a/customerio/analytics/test/client.py
+++ b/customerio/analytics/test/client.py
@@ -318,7 +318,7 @@ class TestClient(unittest.TestCase):
 
     def test_user_defined_upload_size(self):
         client = Client('testsecret', on_error=self.fail,
-                        upload_size=10, upload_interval=3)
+                        upload_size=10, upload_interval=0.3)
 
         def mock_post_fn(*args, **kwargs):
             self.assertEqual(len(kwargs['batch']), 10)
@@ -331,6 +331,17 @@ class TestClient(unittest.TestCase):
                 client.identify('userId', {'trait': 'value'})
             time.sleep(1)
             self.assertEqual(mock_post.call_count, 2)
+
+    def test_user_defined_upload_interval(self):
+        upload_interval = 0.3
+        client = Client('testsecret', on_error=self.fail,
+                        upload_size=100, upload_interval=upload_interval)
+
+        with mock.patch('customerio.analytics.consumer.post') as mock_post:
+            for _ in range(3):
+                client.identify('userId', {'trait': 'value'})
+                time.sleep(upload_interval * 1.1)
+            self.assertEqual(mock_post.call_count, 3)
 
     def test_user_defined_timeout(self):
         client = Client('testsecret', timeout=10)

--- a/customerio/analytics/test/consumer.py
+++ b/customerio/analytics/test/consumer.py
@@ -198,12 +198,10 @@ class TestConsumer(unittest.TestCase):
             q.join()
             self.assertEqual(mock_post.call_count, 2)
 
-    @classmethod
-    def test_proxies(cls):
-        consumer = Consumer(None, 'testsecret', proxies='203.243.63.16:80')
-        track = {
-            'type': 'track',
-            'event': 'python event',
-            'userId': 'userId'
+    def test_proxies(self):
+        proxies = {
+            'http': 'http://192.0.2.1:80',
+            'https': 'http://192.0.2.1:80',
         }
-        consumer.request([track])
+        consumer = Consumer(None, 'testsecret', proxies=proxies)
+        self.assertEqual(consumer.proxies, proxies)

--- a/customerio/analytics/test/request.py
+++ b/customerio/analytics/test/request.py
@@ -1,5 +1,6 @@
 from datetime import datetime, date
 import unittest
+import unittest.mock as mock
 import json
 import requests
 
@@ -52,11 +53,34 @@ class TestRequests(unittest.TestCase):
                 'type': 'track'
             }], timeout=0.0001)
 
-    def test_proxies(self):
-        res = post('testsecret', batch=[{
-            'userId': 'userId',
-            'event': 'python event',
-            'type': 'track',
-            'proxies': '203.243.63.16:80'
-        }])
-        self.assertEqual(res.status_code, 200)
+    def test_proxies_passed_to_session(self):
+        proxies = {
+            'https': 'http://proxy.example.com:8080',
+            'http': 'http://proxy.example.com:8080',
+        }
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        with mock.patch('customerio.analytics.request._session.post',
+                        return_value=mock_response) as mock_post:
+            post('testsecret', proxies=proxies, batch=[{
+                'userId': 'userId',
+                'event': 'python event',
+                'type': 'track',
+            }])
+            mock_post.assert_called_once()
+            _, call_kwargs = mock_post.call_args
+            self.assertEqual(call_kwargs['proxies'], proxies)
+
+    def test_no_proxies_by_default(self):
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        with mock.patch('customerio.analytics.request._session.post',
+                        return_value=mock_response) as mock_post:
+            post('testsecret', batch=[{
+                'userId': 'userId',
+                'event': 'python event',
+                'type': 'track',
+            }])
+            mock_post.assert_called_once()
+            _, call_kwargs = mock_post.call_args
+            self.assertNotIn('proxies', call_kwargs)


### PR DESCRIPTION
## Summary

- The `proxies` option on the `Client` constructor was accepted but never actually passed to the underlying `requests` session. The `post()` function in `request.py` built a `kwargs` dict containing `proxies`, but then called `_session.post()` with individual named arguments instead of using that dict.
- Fixed by calling `_session.post(url, **kwargs)` so all options (including `proxies`) flow through.
- Also fixed a latent bug where `timeout` was hardcoded to `15` in the `kwargs` dict instead of using the `timeout` parameter.
- Replaced the existing proxy tests (which didn't actually verify proxies reached the HTTP layer) with tests that mock `_session.post` and assert `proxies` is present in the call arguments.

## Test plan
- [x] `test_proxies_passed_to_session` — verifies `proxies` dict reaches `_session.post` via `post()`
- [x] `test_no_proxies_by_default` — verifies `proxies` is omitted when not set
- [x] `TestClient.test_proxies` — verifies `proxies` flows end-to-end from `Client` constructor through to `_session.post`
- [x] Full test suite passes

I made these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all batch uploads (timeout/proxy behavior); fixes are straightforward but touch the critical outbound HTTP path customers rely on.
> 
> **Overview**
> **HTTP upload options were silently ignored:** `post()` built a `kwargs` dict with `proxies` and `timeout` but called `_session.post()` with separate arguments, so **`Client` proxy settings never reached the wire**. The call now uses `_session.post(url, **kwargs)`, and the request kwargs use the **`timeout` parameter** instead of a hardcoded `15`. **`proxies` is only added when not `None`**.
> 
> Proxy-related tests now **mock `_session.post`** and assert `proxies` is present or omitted; consumer proxy coverage checks stored config. Minor test tweaks add **`upload_interval`** coverage and stabilize batch timing. **`AGENTS.md`** documents opening PRs against **customerio/cdp-analytics-python**; **`CLAUDE.md`** points agents at that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44600a0251c9fa4897a767ab38c400f98c74541b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->